### PR TITLE
Set upstream metadata fields: Bug-Database, Bug-Submit

### DIFF
--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,3 @@
+---
+Bug-Database: https://github.com/topydo/topydo/issues
+Bug-Submit: https://github.com/topydo/topydo/issues/new


### PR DESCRIPTION

Set upstream metadata fields: Bug-Database, Bug-Submit. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/topydo/a6882ef7-c7fe-4954-9d0a-190e25cc74e3.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/a6882ef7-c7fe-4954-9d0a-190e25cc74e3/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/a6882ef7-c7fe-4954-9d0a-190e25cc74e3/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/a6882ef7-c7fe-4954-9d0a-190e25cc74e3/diffoscope)).
